### PR TITLE
Update Extension.php

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -357,6 +357,9 @@ abstract class Extension
      */
     protected static function createMenu($title, $uri, $icon = 'fa-bars', $parentId = 0, array $children = [])
     {
+        
+        $parentId  = intval($parentId);
+        
         $menuModel = config('admin.database.menu_model');
 
         $lastOrder = $menuModel::max('order');


### PR DESCRIPTION
Acts weird sometimes by failing to recognize param $parentId as int and thus recognizes it as string hence issues in insertion of a particular $param childrens into the database